### PR TITLE
Fixing header, moving includes and others 

### DIFF
--- a/power_sums.c
+++ b/power_sums.c
@@ -6,11 +6,7 @@
   TODO: try the Routh-Hurwitz criterion.
 */
 
-#include <flint.h>
-#include <fmpz_poly.h>
-#include <fmpq.h>
-#include <fmpq_mat.h>
-#include <arith.h>
+#include "power_sums.h"
 
 /*
     Use a subresultant (Sturm-Habicht) sequence to test whether a given
@@ -42,7 +38,7 @@ int _fmpz_poly_all_real_roots(fmpz *poly, long n, fmpz *w, int force_squarefree,
   fmpz *c      = w + 2*n;
   fmpz *d      = w + 2*n+1;
   fmpz *t;
-  
+
   if (n <= 2) return(1);
   _fmpz_vec_set(f0, poly, n);
   if (a != NULL && b != NULL)
@@ -50,7 +46,7 @@ int _fmpz_poly_all_real_roots(fmpz *poly, long n, fmpz *w, int force_squarefree,
   _fmpz_poly_derivative(f1, f0, n);
   n--;
   int sgn0_l = fmpz_sgn(f0+n);
-  
+
   while (1) {
     /* At this point deg(f0) = n, deg(f1) = n-1.
        We explicitly compute the pseudoremainder of f0 modulo f1:
@@ -65,52 +61,25 @@ int _fmpz_poly_all_real_roots(fmpz *poly, long n, fmpz *w, int force_squarefree,
     fmpz_neg(d, f1+n);
     _fmpz_vec_scalar_mul_fmpz(f0, f0, n, d);
     _fmpz_vec_scalar_addmul_fmpz(f0, f1, n, c);
-    
+
     if (!force_squarefree && _fmpz_vec_is_zero(f0, n)) return(1);
-    
+
     /* If we miss any one sign change, we cannot have enough. */
     if (fmpz_sgn(f0+n-1) != sgn0_l) return(0);
 
     if (n==1) return(1); /* If f0 is a scalar, it is nonzero and we win. */
-    
+
     /* Extract content from f0; in practice, this seems to do better than
        an explicit subresultant computation. */
     _fmpz_vec_content(c, f0, n);
     _fmpz_vec_scalar_divexact_fmpz(f0, f0, n, c);
-    
+
     /* Swap f0 with f1. */
     t = f0; f0 = f1; f1 = t;
   }
 }
 
-/* Primary data structures for tree exhaustion.
- */
 
-typedef struct ps_static_data {
-  int d, sign, force_squarefree;
-  long node_limit;
-  fmpz_t lead, q;
-  fmpz_mat_t binom_mat;
-  fmpz *cofactor;
-  fmpz *modlist;
-  fmpq_mat_t *hausdorff_mats;
-  fmpq_mat_t *sum_mats;
-  fmpq_t *f;
-} ps_static_data_t;
-
-typedef struct ps_dynamic_data {
-  int d, n, ascend, flag, q_is_1;
-  long node_count;
-  fmpq_mat_t power_sums, sum_prod, hankel_mat, hankel_dets,
-    hausdorff_prod, hausdorff_sums1, hausdorff_sums2;
-  fmpz *pol, *sympol, *upper;
-
-  /* Scratch space */
-  fmpz *w;
-  int wlen; /* = 3*d+10 */
-  fmpq *w2;
-  int w2len; /* = 5 */
-} ps_dynamic_data_t;
 
 /* Set res to floor(a). */
 void fmpq_floor(fmpz_t res, const fmpq_t a) {
@@ -132,7 +101,7 @@ void fmpz_sqrt_c(fmpz_t res, const fmpz_t a) {
   if (!s) fmpz_add_ui(res, res, 1);
 }
 
-/* Set res to floor(a + b sqrt(q)). 
+/* Set res to floor(a + b sqrt(q)).
    For efficiency, we do not assume a and b are canonical;
    we must thus be careful about signs. */
 void fmpq_floor_quad(fmpz_t res, const fmpq_t a,
@@ -146,7 +115,7 @@ void fmpq_floor_quad(fmpz_t res, const fmpq_t a,
     int bnum_s = fmpz_sgn(bnum);
     fmpz *bden = fmpq_denref(b);
     int bden_s = fmpz_sgn(bden);
-    
+
     fmpz_mul(res, aden, bnum);
     fmpz_mul(res, res, res);
     fmpz_mul(res, res, q);
@@ -264,7 +233,7 @@ ps_static_data_t *ps_static_init(int d, fmpz_t q, int coeffsign, fmpz_t lead,
   for (i=0; i<=d; i++)
     for (j=0; j<=d; j++)
       fmpz_bin_uiui(fmpz_mat_entry(st_data->binom_mat, i, j), i, j);
-  
+
   st_data->hausdorff_mats = (fmpq_mat_t *)malloc((d+1)*sizeof(fmpq_mat_t));
   for (i=0; i<=d; i++) {
 
@@ -297,8 +266,8 @@ ps_static_data_t *ps_static_init(int d, fmpz_t q, int coeffsign, fmpz_t lead,
 
     arith_chebyshev_t_polynomial(pol, i);
     for (j=0; j<=d; j++) {
-      
-      /* Coefficients of 2*(i-th Chebyshev polynomial)(x/2). 
+
+      /* Coefficients of 2*(i-th Chebyshev polynomial)(x/2).
          If q != 1, the coeff of x^j is multiplied by q^{floor(i-j)/2}. */
       if (j <= i) {
 	k1 = fmpq_mat_entry(st_data->sum_mats[i], 0, j);
@@ -309,14 +278,14 @@ ps_static_data_t *ps_static_init(int d, fmpz_t q, int coeffsign, fmpz_t lead,
 	fmpq_mul_fmpz(k1, k1, m);
 	if (!fmpz_is_one(st_data->q) && i%2==j%2) {
 	  fmpz_set(m, st_data->q);
-	  fmpz_pow_ui(m, m, (i-j)/2); 
+	  fmpz_pow_ui(m, m, (i-j)/2);
 	  fmpq_mul_fmpz(k1, k1, m);
 	}
       }
 
     }
   }
-  
+
   fmpz_poly_clear(pol);
   fmpz_clear(m);
   fmpz_clear(const1);
@@ -340,10 +309,10 @@ ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist) {
   dy_data->sympol = _fmpz_vec_init(2*d+3);
   if (coefflist != NULL) {
     dy_data->flag = 1; // Activate this process
-    for (i=0; i<=d; i++) 
+    for (i=0; i<=d; i++)
       fmpz_set(dy_data->pol+i, coefflist+i);
   } else dy_data->flag = 0;
-  
+
   fmpq_mat_init(dy_data->power_sums, d+1, 1);
   fmpq_set_si(fmpq_mat_entry(dy_data->power_sums, 0, 0), d, 1);
   fmpq_mat_init(dy_data->hankel_mat, d/2+1, d/2+1);
@@ -364,9 +333,9 @@ ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist) {
   return(dy_data);
 }
 
-/* Split off a subtree. 
+/* Split off a subtree.
    The first process gives up on the current branch, up to the first coefficient that is not uniquely specified;
-   the remaining work is yielded to the second process, which may in turn be split immediately. 
+   the remaining work is yielded to the second process, which may in turn be split immediately.
 */
 void ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) {
   if ((dy_data == NULL) || (dy_data->flag <= 0) || dy_data2->flag) return(NULL);
@@ -447,7 +416,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
   fmpz *q = st_data->q;
   fmpq *f = st_data->f+n-1;
   fmpq *t;
-    
+
   /* Allocate temporary variables from persistent scratch space. */
   fmpz *tpol = dy_data->w;
   fmpz *tpol2 = dy_data->w+d+1;
@@ -457,17 +426,17 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
   fmpz *t2z = dy_data->w+3*d+7;
   fmpz *lower = dy_data->w+3*d+8;
   fmpz *upper = dy_data->w+3*d+9;
-  
+
   fmpq *t0q = dy_data->w2;
   fmpq *t1q = dy_data->w2+1;
   fmpq *t2q = dy_data->w2+2;
   fmpq *t3q = dy_data->w2+3;
   fmpq *t4q = dy_data->w2+4;
 
-  /* Embedded subroutines to adjust lower and upper bounds. 
+  /* Embedded subroutines to adjust lower and upper bounds.
    These use t0z, t0q, t4q as persistent scratch space.
    The pair (val1, val2) stands for val1 + val2*sqrt(q);
-   passing NULL for val2 is a faster variant of passing 0. 
+   passing NULL for val2 is a faster variant of passing 0.
 
   Usage: if g is a monic linear function of the k-th power sum, then
   set_upper(g) or change_upper(g) imposes the condition g >= 0;
@@ -481,7 +450,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
       fmpq_ceil_quad(lower, t0q, t4q, q);
     }
   }
-  
+
   void set_upper(const fmpq_t val1, const fmpq_t val2) {
     fmpq_div(t0q, val1, f);
     if (val2==NULL) fmpq_floor(upper, t0q);
@@ -500,7 +469,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
     }
     if (fmpz_cmp(t0z, lower) > 0) fmpz_set(lower, t0z);
   }
-  
+
   void change_upper(const fmpq_t val1, const fmpq_t val2) {
     fmpq_div(t0q, val1, f);
     if (val2==NULL) fmpq_floor(t0z, t0q);
@@ -525,7 +494,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
   }
 
   /* End embedded subroutines */
-    
+
   /* If k>d, no further coefficients to bound. */
   if (k>d) return(1);
 
@@ -539,7 +508,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
     fmpq_addmul(t, t0q, fmpq_mat_entry(dy_data->power_sums, k-i, 0));
   }
   fmpq_div_fmpz(t, t, pol+d);
-  
+
   /* Condition: the k-th symmetrized power sum must lie in [-2*sqrt(q), 2*sqrt(q)]. */
   fmpq_mat_mul(dy_data->sum_prod, st_data->sum_mats[k], dy_data->power_sums);
   t = fmpq_mat_entry(dy_data->sum_prod, 0, 0);
@@ -559,14 +528,14 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
     fmpq_neg(t1q, t1q);
     set_lower(t, t1q);
     }
-    
+
   /* Compute the divided (n-1)-st derivative of pol, answer in tpol. */
   for (i=0; i<=k; i++)
     fmpz_mul(tpol+i, fmpz_mat_entry(st_data->binom_mat, n-1+i, n-1), pol+n-1+i);
 
-  /* Condition: Descartes' rule of signs applies at -2*sqrt(q), +2*sqrt(q). 
+  /* Condition: Descartes' rule of signs applies at -2*sqrt(q), +2*sqrt(q).
    This is only a new condition for the evaluations at these points. */
-  
+
   fmpq_set_si(t3q, -k, 1);
   fmpq_div_fmpz(t3q, t3q, pol+d);
 
@@ -577,8 +546,8 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
   for (i=0; 2*i+1 <= k; i++) fmpz_mul_2exp(tpol2+i, tpol+2*i+1, 2*i+1);
   _fmpz_poly_evaluate_fmpz(t0z, tpol2, (k+1) / 2, q);
   fmpq_mul_fmpz(t2q, t3q, t0z);
-  
-  change_lower(t1q, t2q);  
+
+  change_lower(t1q, t2q);
   fmpq_neg(t2q, t2q);
   if (k%2==1) change_upper(t1q, t2q);
   else change_lower(t1q, t2q);
@@ -587,7 +556,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
      and Rolle's theorem is satisfied.
    */
   if (fmpz_is_zero(modulus)) {
-    if ((fmpz_sgn(lower) > 0) || (fmpz_sgn(upper) < 0) || 
+    if ((fmpz_sgn(lower) > 0) || (fmpz_sgn(upper) < 0) ||
 	!_fmpz_poly_all_real_roots(tpol, k, tpol2, st_data->force_squarefree,
 				   NULL, NULL)) return(0);
     fmpz_zero(lower);
@@ -597,7 +566,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
 
   if (fmpz_cmp(lower, upper) > 0) return(0);
 
-  /* Condition: nonnegativity of the Hankel determinant. 
+  /* Condition: nonnegativity of the Hankel determinant.
      TODO: reimplement this as a subresultant. */
   if (k%2==0) {
     fmpq_mat_one(dy_data->hankel_mat);
@@ -615,7 +584,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
     else if (st_data->force_squarefree || fmpq_sgn(t0q)) return(0);
     else change_upper(fmpq_mat_entry(dy_data->power_sums, k, 0), NULL);
     if (fmpz_cmp(lower, upper) > 0) return(0);
-  } 
+  }
 
   /* Condition: the Hausdorff moment criterion for having roots in [-2, 2]. */
   fmpq_mat_mul(dy_data->hausdorff_prod, st_data->hausdorff_mats[k], dy_data->power_sums);
@@ -630,7 +599,7 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
     }
   }
   if (fmpz_cmp(lower, upper) > 0) return(0);
-  
+
   /* Condition: log convexity based on Cauchy-Schwarz. */
   /* Todo: extend to q != 1 without losing too much efficiency. */
   if (q_is_1) {
@@ -690,11 +659,11 @@ int set_range_from_power_sums(ps_static_data_t *st_data,
       if (r) fmpz_set(t2z, t1z);
       else fmpz_sub_ui(upper, t1z, 1);
   }
-  
+
   /* Set the new upper bound. */
   fmpz_mul(upper, upper, modulus);
   fmpz_add(dy_data->upper+n-1, pol+n-1, upper);
-  
+
   /* Set the new polynomial value. */
   fmpz_mul(lower, lower, modulus);
   fmpz_add(pol+n-1, pol+n-1, lower);

--- a/power_sums.h
+++ b/power_sums.h
@@ -1,3 +1,10 @@
+#pragma once
+#include <flint/flint.h>
+#include <flint/fmpz_poly.h>
+#include <flint/fmpq.h>
+#include <flint/fmpq_mat.h>
+#include <flint/arith.h>
+
 typedef struct ps_static_data {
   int d, sign, force_squarefree;
   long node_limit;
@@ -32,7 +39,6 @@ ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist);
 void ps_static_clear(ps_static_data_t *st_data);
 void ps_dynamic_clear(ps_dynamic_data_t *dy_data);
 void extract_pol(int *Q, ps_dynamic_data_t *dy_data);
-void *ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2);
+void ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2);
 void step_forward(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int n);
 void next_pol(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps);
-

--- a/weil_polynomials.pyx
+++ b/weil_polynomials.pyx
@@ -84,7 +84,7 @@ cdef extern from "power_sums.h":
                                      int cofactor, fmpz *modlist, long node_limit,
                                      int force_squarefree)
     ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist)
-    void *ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) nogil
+    void ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) nogil
     void ps_static_clear(ps_static_data_t *st_data)
     void ps_dynamic_clear(ps_dynamic_data_t *dy_data)
     void next_pol(ps_static_data_t *st_data, ps_dynamic_data_t *dy_data, int max_steps) nogil

--- a/weil_polynomials.pyx
+++ b/weil_polynomials.pyx
@@ -10,13 +10,11 @@
 
 #encoding=utf8
 #distutils: language = c
-#distutils: libraries = gomp
+#distutils: libraries = gomp flint
 #distutils: sources = power_sums.c
-#distutils: include_dirs = /home/kedlaya/sage/local/include/flint .
 ## Remove the next line if OpenMP is not available
 #distutils: extra_compile_args = -fopenmp
 
-## TODO: remove hard-coding of include directory
 
 r"""
 Iterator for Weil polynomials.

--- a/weil_polynomials.pyx
+++ b/weil_polynomials.pyx
@@ -81,7 +81,7 @@ cdef extern from "power_sums.h":
 
     int has_openmp()
     ps_static_data_t *ps_static_init(int d, fmpz_t q, int coeffsign, fmpz_t lead,
-    		     		     int cofactor, fmpz *modlist, long node_limit,
+                                     int cofactor, fmpz *modlist, long node_limit,
                                      int force_squarefree)
     ps_dynamic_data_t *ps_dynamic_init(int d, fmpz_t q, fmpz *coefflist)
     void *ps_dynamic_split(ps_dynamic_data_t *dy_data, ps_dynamic_data_t *dy_data2) nogil
@@ -98,7 +98,7 @@ cdef class dfs_manager:
     cdef ps_dynamic_data_t **dy_data_buf
 
     def __cinit__(self, int d, q, coefflist, modlist, int sign, int cofactor,
-                        long node_limit, int parallel, int force_squarefree):
+                  long node_limit, int parallel, int force_squarefree):
         cdef fmpz_t temp_lead
         cdef fmpz_t temp_q
         cdef fmpz *temp_array
@@ -112,23 +112,23 @@ cdef class dfs_manager:
         fmpz_set_mpz(temp_lead, Integer(coefflist[-1]).value)
         fmpz_init(temp_q)
         fmpz_set_mpz(temp_q, Integer(q).value)
-        temp_array = _fmpz_vec_init(d+1)
-        for i in range(d+1):
-            fmpz_set_mpz(temp_array+i, Integer(modlist[i]).value)
+        temp_array = _fmpz_vec_init(d + 1)
+        for i in range(d + 1):
+            fmpz_set_mpz(temp_array + i, Integer(modlist[i]).value)
         self.ps_st_data = ps_static_init(d, temp_q, sign, temp_lead, cofactor,
                                          temp_array, node_limit, force_squarefree)
 
         # Initialize processes, but assign work to only one process.
         # Other processes will get initialized later via work-stealing.
-        for i in range(d+1):
-            fmpz_set_mpz(temp_array+i, Integer(coefflist[i]).value)
+        for i in range(d + 1):
+            fmpz_set_mpz(temp_array + i, Integer(coefflist[i]).value)
         self.dy_data_buf[0] = ps_dynamic_init(d, temp_q, temp_array)
         for i in range(1, self.num_processes):
             self.dy_data_buf[i] = ps_dynamic_init(d, temp_q, NULL)
 
         fmpz_clear(temp_lead)
         fmpz_clear(temp_q)
-        _fmpz_vec_clear(temp_array, d+1)
+        _fmpz_vec_clear(temp_array, d + 1)
 
     def __init__(self, d, q, coefflist, modlist, sign, cofactor,
                         node_limit, parallel, force_squarefree):
@@ -154,31 +154,31 @@ cdef class dfs_manager:
         """
         Advance the tree exhaustion.
         """
-        cdef int i, j, k, d = self.d, t=1, u=0, np = self.num_processes, max_steps=1000
+        cdef int i, j, k, d = self.d, t = 1, u = 0, np = self.num_processes, max_steps = 1000
         cdef long ans_count = 0, ans_max = 10000
         cdef mpz_t z
         cdef Integer temp
         cdef double time1, time2
         ans = []
 
-        k=1
+        k = 1
         time1 = 0
         time2 = 0
-        while (t and not u and ans_count  < ans_max):
+        while (t and not u and ans_count < ans_max):
             time1 -= clock()
             if np == 1: # Serial mode
                 next_pol(self.ps_st_data, self.dy_data_buf[0], max_steps)
                 t = self.dy_data_buf[0].flag
             else: # Parallel mode
                 t = 0
-                k = (k<<1) %np # Note that 2 is a primitive root mod np.
+                k = (k<<1) % np # Note that 2 is a primitive root mod np.
                 with nogil:
                     sig_on()
-                    for i in prange(np, schedule='dynamic'): # Step each process forward
+                    for i in prange(np, schedule='dynamic'):  # Step each process forward
                         next_pol(self.ps_st_data, self.dy_data_buf[i], max_steps)
                         if self.dy_data_buf[i].flag: t += 1
                         if self.dy_data_buf[i].flag == -1: u += 1
-                    for i in prange(np, schedule='dynamic'): # Redistribute work to idle processes
+                    for i in prange(np, schedule='dynamic'):  # Redistribute work to idle processes
                         j = (i-k) % np
                         ps_dynamic_split(self.dy_data_buf[j], self.dy_data_buf[i])
                     sig_off()
@@ -188,7 +188,7 @@ cdef class dfs_manager:
                 if self.dy_data_buf[i].flag == 2: # Extract a solution
                     l = []
                     # Convert a vector of fmpz's into mpz's, then Integers.
-                    for j in range(2*d+3):
+                    for j in range(2 * d + 3):
                         flint_mpz_init_set_readonly(z, &self.dy_data_buf[i].sympol[j])
                         temp = Integer()
                         mpz_set(temp.value, z)
@@ -223,10 +223,10 @@ class WeilPolynomials_iter():
         d = Integer(d)
         if sign != 1 and sign != -1:
             return ValueError("Invalid sign")
-        if not q.is_integer() or q<=0:
+        if not q.is_integer() or q <= 0:
             return ValueError("q must be a positive integer")
-        if d%2==0:
-            if sign==1:
+        if d % 2 == 0:
+            if sign == 1:
                 d2 = d//2
                 num_cofactor = 0
             else:
@@ -236,8 +236,10 @@ class WeilPolynomials_iter():
             if not q.is_square():
                 return ValueError("Degree must be even if q is not a square")
             d2 = d//2
-            if sign==1: num_cofactor = 1
-            else: num_cofactor = 2
+            if sign == 1:
+                num_cofactor = 1
+            else:
+                num_cofactor = 2
         try:
             leadlist = list(lead)
         except TypeError:
@@ -246,9 +248,9 @@ class WeilPolynomials_iter():
         modlist = []
         for i in leadlist:
             try:
-                (j,k) = i
+                (j, k) = i
             except TypeError:
-                (j,k) = (i,0)
+                (j, k) = (i, 0)
             j = Integer(j)
             k = Integer(k)
             if len(modlist) == 0 and k != 0:
@@ -305,23 +307,24 @@ class WeilPolynomials_iter():
 
     def node_count(self):
         r"""
-        Return the number of terminal nodes found in the tree, excluding 
+        Return the number of terminal nodes found in the tree, excluding
         actual solutions.
         """
         if self.process is None:
             return self.count
         return self.process.node_count()
 
+
 class WeilPolynomials():
     r"""
-    Iterable for Weil polynomials, i.e., integer polynomials with all complex 
+    Iterable for Weil polynomials, i.e., integer polynomials with all complex
     roots having a particular absolute value.
 
     If parallel is False, then the order of values is descending lexicographical
     (i.e., polynomials with the largest coefficients of largest degrees sort first).
 
     If parallel is True, then the order of values is not specified. (Beware that
-    due to increased overhead, parallel execution may not yield a significant 
+    due to increased overhead, parallel execution may not yield a significant
     speedup for small problem sizes.)
 
     EXAMPLES:
@@ -339,13 +342,13 @@ class WeilPolynomials():
     By Kronecker's theorem, a monic integer polynomial has all roots of absolute
     value 1 if and only if it is a product of cyclotomic polynomials. For such a
     product to have positive sign of the functional equation, the factors `x-1`
-    and `x+1` must each occur with even multiplicity. This code confirms 
+    and `x+1` must each occur with even multiplicity. This code confirms
     Kronecker's theorem for polynomials of degree 6::
         sage: P.<x> = PolynomialRing(ZZ)
         sage: d = 6
         sage: ans1 = list(WeilPolynomials(d, 1, 1))
         sage: ans1.sort()
-        sage: l = [(x-1)^2, (x+1)^2] + [cyclotomic_polynomial(n,x) 
+        sage: l = [(x-1)^2, (x+1)^2] + [cyclotomic_polynomial(n,x)
         ....:     for n in range(3, 2*d*d) if euler_phi(n) <= d]
         sage: w = WeightedIntegerVectors(d, [i.degree() for i in l])
         sage: ans2 = [prod(l[i]^v[i] for i in range(len(l))) for v in w]
@@ -366,7 +369,7 @@ class WeilPolynomials():
     def __init__(self, d, q, sign=1, lead=1, node_limit=None, parallel=False, squarefree=False):
         if parallel and not has_openmp():
             raise RuntimeError("Parallel execution not supported")
-        self.data = (d,q,sign,lead,node_limit,parallel,squarefree)
+        self.data = (d, q, sign, lead, node_limit, parallel, squarefree)
 
     def __iter__(self):
         w = WeilPolynomials_iter(*self.data)
@@ -378,4 +381,4 @@ class WeilPolynomials():
         Return the number of terminal nodes found in the tree, excluding actual solutions.
         """
         return self.w.node_count()
-    
+


### PR DESCRIPTION
Did a couple of things:
1-  moved all includes to power_sums.h, and placed a  `#pragma once` on top so we don't have double definitions. 
2-  fixed the flint includes from `#include <foo.h>` to `#include <flint/foo.h>`
3-  added flint to the libraries
4- removed the unnecessary include_dir, as sage must know where flint is. Before wouldn't find it because it was missing the `flint/` in the includes.
5- added and removed some white space througout. (for a first review consider disabling white space diff)
